### PR TITLE
To processable other than String type and Array type.

### DIFF
--- a/lib/fluent/plugin/out_airbrake_logger.rb
+++ b/lib/fluent/plugin/out_airbrake_logger.rb
@@ -103,8 +103,7 @@ class Fluent::AirbrakeLoggerOutput < Fluent::Output
   end
 
   def cut_down_message(message)
-    message_to_s = message.is_a?(Array) ? message.join : message
-    message_to_s[0, @cut_off_char]
+    message_to_s.to_s[0, @cut_off_char]
   end
 
   def build_error_backtrace(record)


### PR DESCRIPTION
`message` parameter of cut_down_message can only handle `String` or `Array`.
This PR allows processing other than `String` and `Array`.

