### PR TITLE
Fix syntax error.

### DIFF
--- a/lib/fluent/plugin/out_airbrake_logger.rb
+++ b/lib/fluent/plugin/out_airbrake_logger.rb
@@ -103,7 +103,7 @@ class Fluent::AirbrakeLoggerOutput < Fluent::Output
   end
 
   def cut_down_message(message)
-    message_to_s.to_s[0, @cut_off_char]
+    message.to_s[0, @cut_off_char]
   end
 
   def build_error_backtrace(record)


### PR DESCRIPTION
Fix syntax error embedded in https://github.com/ohsawa0515/fluent-plugin-airbrake-logger/pull/5.